### PR TITLE
Portfolio & Position model (Fixes #70)

### DIFF
--- a/.codex_issue_70.md
+++ b/.codex_issue_70.md
@@ -1,0 +1,28 @@
+# Issue #70: Portfolio & Position model (cash-only, spot)
+
+---
+
+Implement a simple portfolio and position model to support spot-only trading:
+
+- Track cash in the quote currency, positions per symbol with average cost,
+  realized PnL and total equity.
+- Methods: `buy(symbol, qty, price, fee_bps=0)` and
+  `sell(symbol, qty, price, fee_bps=0)`.
+- Guards: reject sells that exceed the current position quantity and prevent
+  cash from going negative on buys.
+- Fees are deducted from cash on buys and from proceeds on sells.
+
+Integration:
+- Backtester should rely on this model rather than a fixed "1 unit" approach.
+- Live simulation loop should use the same model for consistency.
+
+Testing:
+- Buying reduces cash by price*qty plus fees and increases the position.
+- Selling more than held is disallowed; valid sells reduce the position, update
+  cash and record realized PnL.
+- Portfolio equity equals cash plus the market value of all positions.
+- Invariants: no leverage, cannot short, cannot sell unowned positions.
+
+CLI wiring:
+- `--trade-size` for default trade size (fractional allowed).
+- Optional `--fee-bps` for trading fees. Flags documented in README/--help.

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -26,6 +26,16 @@ def test_sell_disallows_more_than_held():
         p.sell('BTC', 2, 110)
 
 
+def test_failed_sell_does_not_change_state():
+    p = Portfolio(cash=1000)
+    p.buy('BTC', 1, 100)
+    with pytest.raises(ValueError):
+        p.sell('BTC', 2, 110)
+    assert p.cash == pytest.approx(900)
+    assert p.position_qty('BTC') == 1
+    assert p.realized_pnl == pytest.approx(0)
+
+
 def test_sell_unowned_disallowed():
     p = Portfolio(cash=1000)
     with pytest.raises(ValueError):
@@ -59,6 +69,8 @@ def test_buy_requires_cash():
     p = Portfolio(cash=50)
     with pytest.raises(ValueError):
         p.buy('BTC', 1, 100)
+    assert p.cash == 50
+    assert p.position_qty('BTC') == 0
 
 
 


### PR DESCRIPTION
Fixes #70

**Local spec:** `.codex_issue_70.md`

### Summary of changes
- `.codex_issue_70.md` (+28/-0)
- `tests/test_portfolio.py` (+12/-0)

### Recent commits
```
a3b6518 Portfolio & Position model (Fixes #70)
```