### PR TITLE
Portfolio & Position model (Fixes #72)

### DIFF
--- a/.codex_issue_72.md
+++ b/.codex_issue_72.md
@@ -1,0 +1,29 @@
+# Issue #72: Portfolio & Position model (cash-only, spot)
+
+---
+
+Implement a Portfolio and Position model for spot-only trading.
+
+Requirements:
+- Track cash (quote currency), per-symbol positions, average cost, realized PnL, and equity.
+- Methods: buy(symbol, qty, price, fee_bps=0) and sell(symbol, qty, price, fee_bps=0).
+- Guards: disallow sells exceeding held quantity and prevent cash from dropping below zero.
+- Fees: deducted from cash on buys and from proceeds on sells.
+
+Integration:
+- Backtester uses this model instead of ad-hoc "1 unit" logic.
+- Live loop (simulation mode) uses the same model for consistency.
+
+Tests:
+- Buying reduces cash by price*qty + fees and increases position.
+- Selling disallows more than held; valid sells reduce position, update cash, record realized PnL.
+- Portfolio equity = cash + Σ(position_qty * last_price).
+- Invariants: no leverage, cannot short, cannot sell unowned.
+
+CLI wiring:
+- Configurable default trade_size (fractional allowed) and optional fee_bps parameter.
+- Flags documented in README or --help.
+
+Lint: repo passes flake8.
+
+Important: keep current strategies intact; only refactor execution/accounting to use the new model.

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -93,3 +93,14 @@ def test_buy_sell_positive_qty_price():
     with pytest.raises(ValueError):
         p.sell('BTC', 1, -100)
 
+
+def test_equity_uses_cached_prices():
+    """Equity should use last known prices if none are provided."""
+    p = Portfolio(cash=1000)
+    p.buy('BTC', 1, 100)
+    # first call updates cached price
+    p.equity({'BTC': 120})
+    # subsequent call without prices uses cached value
+    expected = p.cash + 120
+    assert p.equity() == pytest.approx(expected)
+


### PR DESCRIPTION
Fixes #72

**Local spec:** `.codex_issue_72.md`

### Summary of changes
- `trading_bot/portfolio.py` (+39/-6)
- `tests/test_portfolio.py` (+27/-0)
- `.codex_issue_72.md` (+41/-0)

### Recent commits
```
16dc642 Portfolio & Position model (Fixes #72)
```

------
https://chatgpt.com/codex/tasks/task_e_689669f5d73c832aa32bba530f3f4ff4