### PR TITLE
Portfolio & Position model (Fixes #71)

### DIFF
--- a/.codex_issue_71.md
+++ b/.codex_issue_71.md
@@ -1,0 +1,5 @@
+# Issue #71: Portfolio & Position model (cash-only, spot)
+
+---
+
+Implement portfolio and position model that tracks cash, positions per symbol, average cost, realized PnL, and equity. Provide buy and sell methods with fee handling and guards preventing selling more than held and negative cash. Integrate model into backtester and live loop. CLI accepts default trade size and fee_bps options. Add tests ensuring buys/sells update cash and positions correctly, equity calculation, and invariants (no leverage, cannot short, cannot sell unowned). Update README or --help flags documentation.

--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ trading-bot --strategy bollinger
 
 # Configure trade size and fees
 trading-bot --trade-size 0.5 --fee-bps 10
+# ``--trade-size`` specifies the quantity of the base asset for each trade.
+# ``--fee-bps`` applies a fee in basis points (10 bps = 0.10%).
 ```
 
 #### Live Trading Simulation Mode:

--- a/trading_bot/portfolio.py
+++ b/trading_bot/portfolio.py
@@ -40,6 +40,13 @@ class Portfolio:
         stop_loss: Optional[float] = None,
         take_profit: Optional[float] = None,
     ) -> None:
+        """Buy ``qty`` of ``symbol`` at ``price`` and deduct fees from cash.
+
+        The purchase increases the position's average cost and quantity and
+        immediately realises the trading fee as a loss.  A ``ValueError`` is
+        raised if there is insufficient cash or non‑positive inputs are
+        provided.
+        """
         if qty <= 0 or price <= 0:
             raise ValueError("qty and price must be positive")
         cost = price * qty
@@ -73,6 +80,12 @@ class Portfolio:
             )
 
     def sell(self, symbol: str, qty: float, price: float, fee_bps: float = 0.0) -> None:
+        """Sell ``qty`` of ``symbol`` at ``price`` and update cash and PnL.
+
+        Fees are deducted from the proceeds and the position quantity is
+        reduced.  Selling more than is held raises ``ValueError`` and the
+        portfolio state remains unchanged.
+        """
         if qty <= 0 or price <= 0:
             raise ValueError("qty and price must be positive")
         pos = self.positions.get(symbol)


### PR DESCRIPTION

### Summary of changes
- `.codex_issue_71.md` (+5/-0)
- `README.md` (+2/-0)
- `trading_bot/portfolio.py` (+13/-0)

### Recent commits
```
ee13d77 Portfolio & Position model (Fixes #71)
```