### PR TITLE
Portfolio & Position model (Fixes #95)

### DIFF
--- a/.codex_issue_95.md
+++ b/.codex_issue_95.md
@@ -1,0 +1,19 @@
+# Issue #95: Portfolio & Position model (cash-only, spot)
+
+---
+
+Implement a Portfolio/Position model for spot-only trading:
+- Track cash (quote currency), positions per symbol with qty and avg cost, realized PnL, and equity.
+- Methods: buy(symbol, qty, price, fee_bps=0), sell(symbol, qty, price, fee_bps=0).
+- Guards: refuse sells if qty > position qty; never reduce cash below zero.
+- Fees deducted from cash on buys and from proceeds on sells.
+
+Integration:
+- Backtester and live loop use this model instead of ad-hoc logic.
+- CLI supports configurable default trade_size (fractional allowed) and fee_bps.
+
+Tests:
+- Buying reduces cash by cost + fees, increases position.
+- Selling disallows more than held; valid sells reduce position, update cash, record PnL.
+- Equity = cash + sum(position_qty * last_price).
+- Invariants: no leverage, cannot short, cannot sell unowned.

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -125,3 +125,10 @@ def test_fractional_trades_and_fees():
     assert p.cash == pytest.approx(1000 - 50 - 0.125 + 22 - 0.055)
     assert p.position_qty('BTC') == pytest.approx(0.3)
     assert p.realized_pnl == pytest.approx(1.82)
+
+def test_sell_closes_position_and_clears_price():
+    p = Portfolio(cash=1000)
+    p.buy('BTC', 1, 100)
+    p.sell('BTC', 1, 110, fee_bps=0)
+    assert 'BTC' not in p.positions
+    assert 'BTC' not in p.last_prices


### PR DESCRIPTION
Fixes #95

**Local spec:** `.codex_issue_95.md`

### Summary of changes
- `.codex_issue_95.md` (+19/-0)
- `tests/test_portfolio.py` (+7/-0)

### Recent commits
```
95297c9 Portfolio & Position model (Fixes #95)
```