### PR TITLE
Add broker abstraction and paper trading support

### DIFF
--- a/config.json
+++ b/config.json
@@ -14,8 +14,13 @@
     "api_secret": "",
     "api_passphrase": "",
     "trade_size": 0.001,
-    "fee_bps": 0,
+    "fee_bps": 10,
     "exchange": "coinbase",
+    "broker": {
+        "type": "paper",
+        "fees_bps": 10,
+        "slippage_bps": 5
+    },
     "risk": {
         "fees_bps": 10,
         "slippage_bps": 5,

--- a/tests/test_paper_broker.py
+++ b/tests/test_paper_broker.py
@@ -1,0 +1,28 @@
+import pytest
+from trading_bot.broker import PaperBroker
+
+
+def test_buy_and_sell_updates_balances():
+    broker = PaperBroker(starting_cash=1000, fees_bps=10, slippage_bps=0)
+    broker.set_price('BTC', 100)
+    broker.create_order('buy', 'BTC', 1)
+    balances = broker.get_balances()
+    assert balances['cash'] == pytest.approx(1000 - 100 - 0.1)
+    broker.set_price('BTC', 110)
+    broker.create_order('sell', 'BTC', 1)
+    balances = broker.get_balances()
+    assert balances['cash'] == pytest.approx(1000 - 100 - 0.1 + 110 - 0.11)
+
+
+def test_cannot_sell_without_holdings():
+    broker = PaperBroker(starting_cash=1000, fees_bps=0, slippage_bps=0)
+    broker.set_price('BTC', 100)
+    with pytest.raises(ValueError):
+        broker.create_order('sell', 'BTC', 1)
+
+
+def test_cannot_buy_beyond_cash():
+    broker = PaperBroker(starting_cash=50, fees_bps=0, slippage_bps=0)
+    broker.set_price('BTC', 100)
+    with pytest.raises(ValueError):
+        broker.create_order('buy', 'BTC', 1)

--- a/trading_bot/broker/__init__.py
+++ b/trading_bot/broker/__init__.py
@@ -1,0 +1,5 @@
+"""Broker interfaces for trading bot."""
+from .base import Broker
+from .paper import PaperBroker
+
+__all__ = ["Broker", "PaperBroker"]

--- a/trading_bot/broker/base.py
+++ b/trading_bot/broker/base.py
@@ -1,0 +1,28 @@
+"""Abstract broker interface."""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from typing import Dict, Any
+
+
+class Broker(ABC):
+    """Abstract base class for execution brokers."""
+
+    def __init__(self, fees_bps: float = 0.0) -> None:
+        self.fees_bps = fees_bps
+
+    @abstractmethod
+    def get_balances(self) -> Dict[str, float]:
+        """Return cash and position balances."""
+
+    @abstractmethod
+    def get_price(self, symbol: str) -> float:
+        """Return current price for ``symbol``."""
+
+    @abstractmethod
+    def create_order(self, side: str, symbol: str, qty: float, type: str = "market") -> Dict[str, Any]:
+        """Execute an order and return execution details."""
+
+    @abstractmethod
+    def get_open_positions(self) -> Dict[str, float]:
+        """Return open positions keyed by symbol."""

--- a/trading_bot/broker/paper.py
+++ b/trading_bot/broker/paper.py
@@ -1,0 +1,64 @@
+"""Paper trading broker implementation."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Dict, Any
+
+from .base import Broker
+from trading_bot.portfolio import Portfolio
+
+
+@dataclass
+class PaperBroker(Broker):
+    """Simple in-memory paper trading broker."""
+
+    starting_cash: float = 0.0
+    fees_bps: float = 0.0
+    slippage_bps: float = 0.0
+
+    def __post_init__(self) -> None:
+        super().__init__(fees_bps=self.fees_bps)
+        self.portfolio = Portfolio(cash=self.starting_cash)
+        self.prices: Dict[str, float] = {}
+        self.name = "paper"
+
+    def set_price(self, symbol: str, price: float) -> None:
+        self.prices[symbol] = price
+
+    def get_price(self, symbol: str) -> float:
+        price = self.prices.get(symbol)
+        if price is None:
+            raise ValueError(f"price for {symbol} not set")
+        return price
+
+    # Broker interface -------------------------------------------------
+    def get_balances(self) -> Dict[str, float]:
+        balances = {sym: pos.qty for sym, pos in self.portfolio.positions.items()}
+        balances["cash"] = self.portfolio.cash
+        return balances
+
+    def get_open_positions(self) -> Dict[str, float]:
+        return {sym: pos.qty for sym, pos in self.portfolio.positions.items()}
+
+    def create_order(self, side: str, symbol: str, qty: float, type: str = "market") -> Dict[str, Any]:
+        if type != "market":
+            raise NotImplementedError("only market orders supported in PaperBroker")
+        price = self.get_price(symbol)
+        slip = self.slippage_bps / 10_000
+        exec_price = price * (1 + slip) if side == "buy" else price * (1 - slip)
+        fee = exec_price * qty * self.fees_bps / 10_000
+        ts = datetime.utcnow().strftime("%Y-%m-%d %H:%M:%S")
+        if side == "buy":
+            self.portfolio.buy(symbol, qty, exec_price, fee_bps=self.fees_bps)
+        else:
+            self.portfolio.sell(symbol, qty, exec_price, fee_bps=self.fees_bps)
+        return {
+            "timestamp": ts,
+            "symbol": symbol,
+            "side": side,
+            "qty": qty,
+            "price": exec_price,
+            "fee": fee,
+            "broker": self.name,
+        }


### PR DESCRIPTION
## What
- introduce pluggable Broker interface with PaperBroker
- log executed trades to SQLite via new `trades` table
- wire broker config and CLI options into live trading
- cover paper broker balances and constraints with unit tests

## Why
- decouples strategies from execution and enables paper trading

## How
- abstract Broker base class and in-memory PaperBroker
- extended signal logger to record executed trades
- config adds `broker` section with fees and slippage

## Tests
- `pytest -q`
- `flake8`

## Screens / Output

## Breaking changes / Migrations
- `config.json` now includes a `broker` section

------
https://chatgpt.com/codex/tasks/task_e_689733d3ae84832a8c235b535df1800c