### PR TITLE
Portfolio & Position model (Fixes #99)

### DIFF
--- a/tests/test_signal_dedup.py
+++ b/tests/test_signal_dedup.py
@@ -1,0 +1,15 @@
+import os
+import sys
+import pandas as pd
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+from trading_bot.signal_logger import mark_signal_handled
+
+
+def test_mark_signal_handled(tmp_path):
+    db_file = tmp_path / "signals.db"
+    ts = pd.Timestamp('2024-01-01 00:00:00').isoformat()
+    first = mark_signal_handled('BTC/USDT', 'sma', '1m', ts, 'buy', db_path=str(db_file))
+    assert first is False
+    second = mark_signal_handled('BTC/USDT', 'sma', '1m', ts, 'buy', db_path=str(db_file))
+    assert second is True

--- a/trading_bot/signal_logger.py
+++ b/trading_bot/signal_logger.py
@@ -107,3 +107,58 @@ def get_signals_from_db(symbol=None, strategy_id=None, limit=None, db_path=None)
     except Exception as e:
         logging.error(f"Error retrieving signals from database: {e}")
         return []
+
+
+def _create_processed_table(cursor):
+    """Ensure table for processed signals exists."""
+    cursor.execute(
+        """
+        CREATE TABLE IF NOT EXISTS processed_signals (
+            strategy_id TEXT NOT NULL,
+            symbol TEXT NOT NULL,
+            timeframe TEXT NOT NULL,
+            signal_ts TEXT NOT NULL,
+            action TEXT NOT NULL,
+            PRIMARY KEY (strategy_id, symbol, timeframe, signal_ts, action)
+        )
+        """
+    )
+
+
+def mark_signal_handled(
+    symbol: str,
+    strategy_id: str,
+    timeframe: str,
+    signal_ts: str,
+    action: str,
+    db_path: str | None = None,
+) -> bool:
+    """Record a signal and return True if it was already processed.
+
+    The unique key ``(strategy_id, symbol, timeframe, signal_ts, action)``
+    is stored in ``processed_signals``.  Subsequent calls with the same key
+    return ``True`` without modifying state, allowing callers to skip
+    duplicate work.
+    """
+    if db_path is None:
+        db_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "signals.db")
+
+    try:
+        with sqlite3.connect(db_path) as conn:
+            cursor = conn.cursor()
+            _create_processed_table(cursor)
+            try:
+                cursor.execute(
+                    """
+                    INSERT INTO processed_signals(strategy_id, symbol, timeframe, signal_ts, action)
+                    VALUES (?, ?, ?, ?, ?)
+                    """,
+                    (strategy_id, symbol, timeframe, signal_ts, action),
+                )
+                conn.commit()
+                return False
+            except sqlite3.IntegrityError:
+                return True
+    except sqlite3.Error as e:
+        logging.error(f"Database error: {e}")
+        raise


### PR DESCRIPTION
## What
- add persistent signal de-duplication backed by SQLite
- support multiple symbols, configurable intervals and structured logging in live mode
- add regression test for deduplication helper

## Why
- prevent duplicate orders from repeated signals

## How
- track processed signals with a unique key
- reuse table in live loop to skip duplicates and log decision as JSON

## Tests
- `pytest -q`
- `flake8`

## Screens / Output

## Breaking changes / Migrations

------
https://chatgpt.com/codex/tasks/task_e_689733e07320832aa1b38e9846b4fea0