### PR TITLE
[Docs] Add Live Trading Guide & Safety Checklist

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ trading-bot --live --symbol ETH/USDT --sma-short 10 --sma-long 30
 TRADING_BOT_API_KEY=your_key TRADING_BOT_API_SECRET=your_secret \
 trading-bot --live --live-trade --symbol BTC/USDT
 
+For a step-by-step safety checklist before enabling real trades, see [Live Trading Guide & Safety Checklist](docs/live_trading.md).
+
 #### Alternative: Direct Python execution:
 ```bash
 # Basic usage (uses config.json defaults)

--- a/docs/live_trading.md
+++ b/docs/live_trading.md
@@ -1,0 +1,38 @@
+# Live Trading Guide & Safety Checklist
+
+This guide helps you move from paper trading to small real trades safely.
+
+## 1. Configure Environment Variables
+Set your exchange API keys so the bot can authenticate:
+
+```bash
+export TRADING_BOT_API_KEY="your_api_key"
+export TRADING_BOT_API_SECRET="your_api_secret"
+```
+Keep these secrets secure and never commit them to source control.
+
+## 2. Start with a Dry Run
+Run the bot in live mode **without** enabling real trades to verify behaviour and logging:
+
+```bash
+trading-bot --live --symbol BTC/USDT
+```
+Confirm that orders are not executed and outputs look correct.
+
+## 3. Understand Fees and Minimum Lot Sizes
+Check your exchange for trading fees and minimum order quantities. Configure the bot accordingly using `--fee-bps` and `--trade-size` so orders satisfy exchange rules.
+
+## 4. Execute a Tiny Real Trade
+When confident, place the smallest possible trade to ensure everything works end to end:
+
+```bash
+TRADING_BOT_API_KEY=your_api_key TRADING_BOT_API_SECRET=your_api_secret \
+trading-bot --live --live-trade --symbol BTC/USDT --trade-size 0.001
+```
+Monitor the trade result and logs closely.
+
+## 5. Have a Rollback Plan
+Be prepared to disable API keys or stop the bot immediately if unexpected behaviour occurs. Keep a manual record of changes and trades so you can revert settings or positions quickly.
+
+Following this checklist helps reduce risk as you transition from simulation to real markets.
+


### PR DESCRIPTION
## Summary
- add live trading guide with environment setup, dry-run steps, fee checks, tiny trade, and rollback plan
- link guide from README to help users transition safely from paper to real trades

## Testing
- `pytest -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_689772425df0832aa7cfd9621c97167b