### PR TITLE
Centralize configuration access

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -9,15 +9,7 @@ import sqlite3
 import ccxt
 from trading_bot.exchange import create_exchange
 
-# Load config.json to determine default exchange
-with open("config.json") as f:
-    config = json.load(f)
-
-exchange_name = config.get("exchange", "binance")
-exchange = create_exchange(exchange_name=exchange_name)
-
-# Optional debug line in sidebar:
-st.sidebar.markdown(f"**Exchange:** `{exchange_name}`")
+from trading_bot.utils.config import get_config
 from trading_bot.signal_logger import (
     get_signals_from_db,
     log_signals_to_db,
@@ -28,6 +20,13 @@ from trading_bot.strategy import sma_crossover_strategy
 from trading_bot.strategies import STRATEGY_REGISTRY, list_strategies
 from trading_bot.performance import compute_equity_curve
 from trading_bot.portfolio import Portfolio
+
+config = get_config()
+exchange_name = config.get("exchange", "binance")
+exchange = create_exchange(exchange_name=exchange_name)
+
+# Optional debug line in sidebar:
+st.sidebar.markdown(f"**Exchange:** `{exchange_name}`")
 
 @st.cache_data(show_spinner=False)
 def _fetch_price_data(symbol: str):

--- a/tests/test_config_layering.py
+++ b/tests/test_config_layering.py
@@ -1,7 +1,8 @@
 import json
 import sys
 
-from trading_bot.main import load_config, parse_args
+from trading_bot.utils.config import load_config
+from trading_bot.main import parse_args
 
 
 def test_config_overlays_and_cli_precedence(tmp_path):

--- a/tests/test_risk_config.py
+++ b/tests/test_risk_config.py
@@ -5,7 +5,8 @@ import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
 from trading_bot.risk_config import get_risk_config
-from trading_bot.main import parse_args, load_config
+from trading_bot.main import parse_args
+from trading_bot.utils.config import load_config
 
 
 def test_default_risk_config():

--- a/trading_bot/utils/config.py
+++ b/trading_bot/utils/config.py
@@ -1,0 +1,63 @@
+import json
+import logging
+import os
+from functools import lru_cache
+from typing import Dict
+
+
+def _deep_update(base: Dict, override: Dict) -> Dict:
+    """Recursively merge ``override`` into ``base``."""
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(base.get(key), dict):
+            _deep_update(base[key], value)
+        else:
+            base[key] = value
+    return base
+
+
+def load_config(config_dir: str | None = None) -> Dict:
+    """Load configuration with optional local overrides.
+
+    Parameters
+    ----------
+    config_dir:
+        Directory to load config files from. Defaults to the package root.
+
+    Returns
+    -------
+    dict
+        Merged configuration dictionary.
+    """
+    base_dir = config_dir or os.path.join(
+        os.path.dirname(os.path.dirname(os.path.dirname(__file__)))
+    )
+    config_path = os.path.join(base_dir, "config.json")
+    try:
+        with open(config_path, "r") as f:
+            config = json.load(f)
+    except FileNotFoundError:
+        logging.warning("config.json not found, using default values")
+        config = {
+            "symbol": "BTC/USDT",
+            "timeframe": "1m",
+            "limit": 500,
+            "sma_short": 5,
+            "sma_long": 20,
+        }
+
+    local_path = os.path.join(base_dir, "config.local.json")
+    if os.path.exists(local_path):
+        try:
+            with open(local_path, "r") as f:
+                local_cfg = json.load(f)
+            config = _deep_update(config, local_cfg)
+        except (OSError, json.JSONDecodeError) as e:  # noqa: BLE001
+            logging.warning(f"Failed loading config.local.json: {e}")
+
+    return config
+
+
+@lru_cache(maxsize=1)
+def get_config(config_dir: str | None = None) -> Dict:
+    """Return the merged configuration, caching the result."""
+    return load_config(config_dir)


### PR DESCRIPTION
## Summary
- add `trading_bot.utils.config` with `load_config` and cached `get_config`
- update CLI and dashboard to use the new configuration helper
- adjust tests to import configuration helpers from the centralized module

## Testing
- `pytest -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_689800d1072c832aa92e02549340a543