### PR TITLE
Continuous Integration Enhancements

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,20 +8,31 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    
+    strategy:
+      matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
+
     steps:
     - uses: actions/checkout@v4
-    
-    - name: Set up Python
+
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
-        python-version: '3.12'
-    
+        python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install -r requirements-dev.txt
-    
-    - name: Run tests with pytest
+
+    - name: Lint with Ruff
       run: |
-        pytest tests/ -v
+        ruff check .
+
+    - name: Type check with MyPy
+      run: |
+        mypy --ignore-missing-imports trading_bot
+
+    - name: Run tests with coverage
+      run: |
+        pytest --cov=trading_bot --cov-report=term --cov-fail-under=80

--- a/dashboard.py
+++ b/dashboard.py
@@ -7,6 +7,7 @@ import os
 import logging
 import sqlite3
 import ccxt
+from typing import Optional
 from trading_bot.exchange import create_exchange
 
 from trading_bot.utils.config import get_config
@@ -55,16 +56,16 @@ def _fetch_price_data(symbol: str):
 def _add_indicators(
     df: pd.DataFrame,
     strategy: str,
-    sma_short: int | None = None,
-    sma_long: int | None = None,
-    rsi_period: int | None = None,
-    lower_thresh: int | None = None,
-    upper_thresh: int | None = None,
-    macd_fast: int | None = None,
-    macd_slow: int | None = None,
-    macd_signal: int | None = None,
-    boll_window: int | None = None,
-    boll_std: float | None = None,
+    sma_short: Optional[int] = None,
+    sma_long: Optional[int] = None,
+    rsi_period: Optional[int] = None,
+    lower_thresh: Optional[int] = None,
+    upper_thresh: Optional[int] = None,
+    macd_fast: Optional[int] = None,
+    macd_slow: Optional[int] = None,
+    macd_signal: Optional[int] = None,
+    boll_window: Optional[int] = None,
+    boll_std: Optional[float] = None,
 ):
     """Return copy of df with strategy-specific indicator columns."""
     df = df.copy()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,3 +42,9 @@ include = ["trading_bot"]
 
 [tool.setuptools.package-data]
 "trading_bot" = ["*.json"]
+
+[tool.ruff]
+line-length = 120
+
+[tool.ruff.lint]
+ignore = ["E402", "F401", "F811", "F841"]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,6 @@
 -r requirements.txt
 pytest
 flake8
+ruff
+mypy
+pytest-cov

--- a/trading_bot/broker/base.py
+++ b/trading_bot/broker/base.py
@@ -26,3 +26,7 @@ class Broker(ABC):
     @abstractmethod
     def get_open_positions(self) -> Dict[str, float]:
         """Return open positions keyed by symbol."""
+
+    @abstractmethod
+    def set_price(self, symbol: str, price: float) -> None:
+        """Cache price for ``symbol`` if supported."""

--- a/trading_bot/broker/ccxt_spot.py
+++ b/trading_bot/broker/ccxt_spot.py
@@ -55,7 +55,7 @@ class CcxtSpotBroker(Broker):
         if exchange is not None:
             self.exchange = exchange
         else:
-            name = exchange_name or os.getenv("EXCHANGE", "binance")
+            name = exchange_name or os.getenv("EXCHANGE") or "binance"
             key = api_key or os.getenv("API_KEY")
             secret = api_secret or os.getenv("API_SECRET")
             params: Dict[str, Any] = {}
@@ -161,6 +161,7 @@ class CcxtSpotBroker(Broker):
                 if attempt == self.retries - 1:
                     raise
                 time.sleep(self.backoff * (2 ** attempt))
+        raise RuntimeError("unreachable")
 
 
 __all__ = ["CcxtSpotBroker"]

--- a/trading_bot/live.py
+++ b/trading_bot/live.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Union
 
 from trading_bot.broker import Broker
 
@@ -22,12 +22,12 @@ class LiveTrader:
     def process_signal(
         self,
         symbol: str,
-        signal: Dict[str, float],
+        signal: Dict[str, Union[float, str]],
         qty: float,
         *,
         stop_loss: Optional[float] = None,
         take_profit: Optional[float] = None,
-    ) -> Dict[str, float]:
+    ) -> Dict[str, Union[float, str]]:
         """Execute a single trading signal for ``symbol``.
 
         Parameters
@@ -42,8 +42,8 @@ class LiveTrader:
         stop_loss, take_profit:
             Optional levels to attach to the resulting position when buying.
         """
-        price = signal["price"]
-        action = signal["action"]
+        price = float(signal["price"])
+        action = str(signal["action"])
         self.broker.set_price(symbol, price)
         order = self.broker.create_order(action, symbol, qty)
         if action == "buy" and (stop_loss is not None or take_profit is not None):
@@ -58,7 +58,7 @@ class LiveTrader:
 
     def run_batch(
         self,
-        signals_by_symbol: Dict[str, List[Dict[str, float]]],
+        signals_by_symbol: Dict[str, List[Dict[str, Union[float, str]]]],
         qtys: Dict[str, float],
     ) -> None:
         """Process lists of signals for multiple symbols sequentially.

--- a/trading_bot/risk/guardrails.py
+++ b/trading_bot/risk/guardrails.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
+from typing import Optional
 
 from trading_bot.notify import send as notify_send
 
@@ -42,9 +43,9 @@ class Guardrails:
     cooldown_minutes: int = 0
 
     # Internal state
-    month_start_equity: float | None = None
+    month_start_equity: Optional[float] = None
     consecutive_losses: int = 0
-    cooldown_until: datetime | None = None
+    cooldown_until: Optional[datetime] = None
 
     def reset_month(self, equity: float) -> None:
         """Reset the month starting equity."""
@@ -72,7 +73,7 @@ class Guardrails:
 
     # ------------------------------------------------------------------
     # Cooldown checks
-    def record_trade(self, pnl: float, *, now: datetime | None = None) -> None:
+    def record_trade(self, pnl: float, *, now: Optional[datetime] = None) -> None:
         """Record the outcome of a trade.
 
         Negative ``pnl`` values count as losses and may trigger a cooldown
@@ -90,7 +91,7 @@ class Guardrails:
         else:
             self.consecutive_losses = 0
 
-    def cooling_down(self, *, now: datetime | None = None) -> bool:
+    def cooling_down(self, *, now: Optional[datetime] = None) -> bool:
         """Return ``True`` if currently in a cooldown period."""
         if self.cooldown_until is None:
             return False
@@ -98,7 +99,7 @@ class Guardrails:
         return now < self.cooldown_until
 
     # ------------------------------------------------------------------
-    def allow_trade(self, equity: float, *, now: datetime | None = None) -> bool:
+    def allow_trade(self, equity: float, *, now: Optional[datetime] = None) -> bool:
         """Return ``True`` if trading is allowed.
 
         Trading is disallowed if either the drawdown threshold has been

--- a/trading_bot/risk/position_sizing.py
+++ b/trading_bot/risk/position_sizing.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import math
+from typing import Optional
 
 from trading_bot.risk_config import PositionSizingConfig
 
@@ -16,8 +17,8 @@ def calculate_position_size(
     price: float,
     equity: float,
     *,
-    lot_size: float | None = None,
-    precision: int | None = None,
+    lot_size: Optional[float] = None,
+    precision: Optional[int] = None,
 ) -> float:
     """Return the trade quantity for a given price and account equity.
 
@@ -29,10 +30,10 @@ def calculate_position_size(
         Current asset price.
     equity: float
         Current portfolio equity in quote currency (e.g., USD).
-    lot_size: float | None
+    lot_size: float or None
         Minimum tradable increment.  If provided the result is floored to a
         multiple of ``lot_size``.
-    precision: int | None
+    precision: int or None
         Optional decimal precision.  If given, the result is rounded down to
         this number of decimal places.
     """

--- a/trading_bot/risk_config.py
+++ b/trading_bot/risk_config.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 
 @dataclass
@@ -160,7 +160,10 @@ def _apply_overrides(config: Dict[str, Any], overrides: Dict[str, Any]) -> Dict[
     return config
 
 
-def get_risk_config(config_dict: Dict[str, Any] | None = None, overrides: Dict[str, Any] | None = None) -> RiskConfig:
+def get_risk_config(
+    config_dict: Optional[Dict[str, Any]] = None,
+    overrides: Optional[Dict[str, Any]] = None,
+) -> RiskConfig:
     """Merge defaults with config/CLI overrides and return a validated RiskConfig."""
     merged: Dict[str, Any] = {}
     _deep_merge(merged, DEFAULT_RISK_DICT.copy())

--- a/trading_bot/signal_logger.py
+++ b/trading_bot/signal_logger.py
@@ -1,6 +1,7 @@
 import sqlite3
 import logging
 import os
+from typing import Optional
 
 from trading_bot.utils.state import default_state_dir
 
@@ -240,7 +241,7 @@ def mark_signal_handled(
     timeframe: str,
     signal_ts: str,
     action: str,
-    db_path: str | None = None,
+    db_path: Optional[str] = None,
 ) -> bool:
     """Record a signal and return True if it was already processed.
 

--- a/trading_bot/strategies/bbands.py
+++ b/trading_bot/strategies/bbands.py
@@ -8,7 +8,7 @@ def bbands_strategy(df, window=20, num_std=2):
     Args:
         df (pd.DataFrame): DataFrame with OHLCV data and 'timestamp'.
         window (int): Moving average window for the middle band.
-        num_std (int | float): Number of standard deviations for the bands.
+        num_std (int or float): Number of standard deviations for the bands.
 
     Returns:
         list: List of signals with timestamp, action and price.

--- a/trading_bot/strategies/confluence.py
+++ b/trading_bot/strategies/confluence.py
@@ -1,6 +1,6 @@
 import logging
 from collections import defaultdict
-from typing import List, Optional
+from typing import DefaultDict, Dict, List, Optional, Any
 import pandas as pd
 
 
@@ -26,7 +26,7 @@ def confluence_strategy(df: pd.DataFrame, members: Optional[List[str]] = None, r
         return []
 
     # Collect signals from member strategies
-    signals_map = defaultdict(list)
+    signals_map: DefaultDict[pd.Timestamp, List[Dict[str, Any]]] = defaultdict(list)
     for name in members:
         strategy_fn = STRATEGY_REGISTRY.get(name)
         if not callable(strategy_fn):

--- a/trading_bot/utils/config.py
+++ b/trading_bot/utils/config.py
@@ -2,7 +2,7 @@ import json
 import logging
 import os
 from functools import lru_cache
-from typing import Dict, Tuple
+from typing import Dict, Tuple, Optional
 
 
 def _deep_update(base: Dict, override: Dict) -> Dict:
@@ -15,7 +15,7 @@ def _deep_update(base: Dict, override: Dict) -> Dict:
     return base
 
 
-def load_config(config_dir: str | None = None) -> Dict:
+def load_config(config_dir: Optional[str] = None) -> Dict:
     """Load configuration with optional local overrides.
 
     Parameters
@@ -106,6 +106,6 @@ def _validate_config(config: Dict) -> None:
 
 
 @lru_cache(maxsize=1)
-def get_config(config_dir: str | None = None) -> Dict:
+def get_config(config_dir: Optional[str] = None) -> Dict:
     """Return the merged configuration, caching the result."""
     return load_config(config_dir)

--- a/trading_bot/utils/logging_config.py
+++ b/trading_bot/utils/logging_config.py
@@ -41,6 +41,7 @@ def setup_logging(level: str = "INFO", state_dir: Optional[str] = None, json_log
     for handler in list(root.handlers):
         root.removeHandler(handler)
 
+    formatter: logging.Formatter
     if json_logs:
         formatter = JsonFormatter()
     else:

--- a/trading_bot/utils/state.py
+++ b/trading_bot/utils/state.py
@@ -7,9 +7,9 @@ def default_state_dir() -> str:
     if os.name == "nt":
         base = os.environ.get("APPDATA")
         if not base:
-            base = Path.home() / "AppData" / "Roaming"
-        return os.path.join(str(base), "trading-bot")
+            base = str(Path.home() / "AppData" / "Roaming")
+        return os.path.join(base, "trading-bot")
     base = os.environ.get("XDG_STATE_HOME")
     if not base:
-        base = Path.home() / ".local" / "state"
-    return os.path.join(str(base), "trading-bot")
+        base = str(Path.home() / ".local" / "state")
+    return os.path.join(base, "trading-bot")


### PR DESCRIPTION
## Summary
- expand test workflow to run ruff, mypy and coverage across Python 3.9–3.12
- add ruff config and dev dependencies for linting and type checking
- replace PEP 604 unions with typing.Optional/Union for Python 3.9 compatibility

## Testing
- `ruff check .`
- `mypy --ignore-missing-imports trading_bot`
- `python -m flake8`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898aa353bac832a8be50ebe63070f4f