### PR TITLE
Use Consistent Logger Instances

### DIFF
--- a/dashboard.py
+++ b/dashboard.py
@@ -22,6 +22,8 @@ from trading_bot.strategies import STRATEGY_REGISTRY, list_strategies
 from trading_bot.performance import compute_equity_curve
 from trading_bot.portfolio import Portfolio
 
+logger = logging.getLogger(__name__)
+
 config = get_config()
 exchange_name = config.get("exchange", "binance")
 exchange = create_exchange(exchange_name=exchange_name)
@@ -206,7 +208,7 @@ with col1:
             try:
                 df = _fetch_price_data(selected_symbol)
             except (ccxt.BaseError, RuntimeError) as api_error:
-                logging.exception("Price data fetch failed")
+                logger.exception("Price data fetch failed")
                 st.warning(
                     f"API unavailable ({str(api_error)[:50]}...), using mock data for demonstration"
                 )
@@ -394,14 +396,14 @@ with col1:
                         )
                         st.rerun()
                     except sqlite3.Error as e:
-                        logging.exception("Error saving signals to database")
+                        logger.exception("Error saving signals to database")
                         st.error(f"Error saving signals: {str(e)}")
             else:
                 st.info("No crossover signals detected in current data")
         else:
             st.error("Failed to fetch price data")
     except Exception as e:  # Catch-all to prevent dashboard crash
-        logging.exception("Error fetching or processing data")
+        logger.exception("Error fetching or processing data")
         st.error(f"Error fetching or processing data: {str(e)}")
 
 with col2:
@@ -414,7 +416,7 @@ with col2:
         else:
             st.metric("Last Trade", "No trades")
     except sqlite3.Error as e:
-        logging.exception("Error loading last trade")
+        logger.exception("Error loading last trade")
         st.error(f"Error loading last trade: {str(e)}")
 
     status_file = "status.json"
@@ -429,7 +431,7 @@ with col2:
             if last_loop:
                 st.metric("Last Loop", last_loop)
         except (OSError, json.JSONDecodeError) as exc:
-            logging.warning("Error reading status file: %s", exc)
+            logger.warning("Error reading status file: %s", exc)
 
     risk_cfg = config.get("risk", {})
     md = risk_cfg.get("max_drawdown", {}).get("monthly_pct", 0.0)
@@ -497,7 +499,7 @@ with col2:
             st.code("python trading_bot/main.py", language="bash")
 
     except sqlite3.Error as e:
-        logging.exception("Error loading signals from database")
+        logger.exception("Error loading signals from database")
         st.error(f"Error loading signals: {str(e)}")
 
     st.subheader("Recent Trades")
@@ -541,7 +543,7 @@ with col2:
                     else:
                         portfolio.sell(sym, qty, price, fee_bps=config.get("broker", {}).get("fees_bps", 0))
                 except ValueError as exc:
-                    logging.warning("Skipping trade %s %s due to error: %s", side, sym, exc)
+                    logger.warning("Skipping trade %s %s due to error: %s", side, sym, exc)
                 history.append({"timestamp": ts, "equity": portfolio.equity({sym: price})})
 
             if history:
@@ -565,7 +567,7 @@ with col2:
         else:
             st.info("No trades found in database")
     except sqlite3.Error as e:
-        logging.exception("Error loading trades from database")
+        logger.exception("Error loading trades from database")
         st.error(f"Error loading trades: {str(e)}")
 
     st.subheader("Error Log")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 ccxt==4.3.86
 pandas==2.2.2
 streamlit==1.38.0
-matplotlib==3.9.1
+matplotlib==3.8.4
 plyer==2.1.0

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,8 +1,7 @@
-import time
 import logging
+import time
 
 import pytest
-import logging
 
 from trading_bot.notify import configure
 from trading_bot.utils.retry import RetryPolicy

--- a/trading_bot/backtest/optimizer.py
+++ b/trading_bot/backtest/optimizer.py
@@ -8,6 +8,9 @@ import pandas as pd
 from trading_bot.backtester import load_csv_data, simulate_equity
 from trading_bot.strategies import STRATEGY_REGISTRY
 
+
+logger = logging.getLogger(__name__)
+
 # Mapping for CLI param aliases to strategy function arguments
 PARAM_ALIASES: Dict[str, Dict[str, str]] = {
     "macd": {
@@ -122,7 +125,11 @@ def optimize(csv_path: str, strategy: str, param_grid: Dict[str, List], split: T
         json.dump(best, f, indent=2)
 
     if best and best["train_metric"] > best["valid_metric"] * 1.5:
-        logging.warning("Possible overfitting: train metric %.4f >> valid metric %.4f", best["train_metric"], best["valid_metric"])
+        logger.warning(
+            "Possible overfitting: train metric %.4f >> valid metric %.4f",
+            best["train_metric"],
+            best["valid_metric"],
+        )
 
     return df_results, best
 

--- a/trading_bot/backtester.py
+++ b/trading_bot/backtester.py
@@ -13,6 +13,9 @@ from trading_bot.portfolio import Portfolio
 from trading_bot.utils.config import get_config
 
 
+logger = logging.getLogger(__name__)
+
+
 CONFIG = get_config()
 DEFAULT_INITIAL_CAPITAL = 10000.0
 DEFAULT_TRADE_SIZE = CONFIG.get("trade_size", 1.0)
@@ -237,18 +240,18 @@ def run_backtest(
 
     if equity_out:
         eq_df.to_csv(equity_out, index=False)
-        logging.info(f"Equity curve saved to {equity_out}")
+        logger.info(f"Equity curve saved to {equity_out}")
     else:
-        logging.info("Equity curve:\n%s", eq_df.tail().to_string(index=False))
+        logger.info("Equity curve:\n%s", eq_df.tail().to_string(index=False))
 
     if stats_out:
         with open(stats_out, 'w') as f:
             json.dump(stats, f, indent=2)
-        logging.info(f"Summary stats saved to {stats_out}")
+        logger.info(f"Summary stats saved to {stats_out}")
 
-    logging.info(f"Net PnL: {stats['net_pnl']:.2f}")
-    logging.info(f"Win rate: {stats['win_rate']:.2f}%")
-    logging.info(f"Max drawdown: {stats['max_drawdown']:.2f}%")
+    logger.info(f"Net PnL: {stats['net_pnl']:.2f}")
+    logger.info(f"Win rate: {stats['win_rate']:.2f}%")
+    logger.info(f"Max drawdown: {stats['max_drawdown']:.2f}%")
 
     if plot and chart_out:
         import matplotlib
@@ -261,6 +264,6 @@ def run_backtest(
         plt.title('Equity Curve')
         plt.tight_layout()
         plt.savefig(chart_out)
-        logging.info(f"Equity chart saved to {chart_out}")
+        logger.info(f"Equity chart saved to {chart_out}")
 
     return stats

--- a/trading_bot/data_fetch.py
+++ b/trading_bot/data_fetch.py
@@ -7,6 +7,9 @@ import ccxt
 from trading_bot.exchange import create_exchange
 from trading_bot.utils.retry import RetryPolicy, default_retry
 
+
+logger = logging.getLogger(__name__)
+
 def fetch_btc_usdt_data(
     symbol: str = "BTC/USDT",
     timeframe: str = "1m",
@@ -45,9 +48,9 @@ def fetch_btc_usdt_data(
         df = pd.DataFrame(ohlcv, columns=['timestamp', 'open', 'high', 'low', 'close', 'volume'])
         df['timestamp'] = pd.to_datetime(df['timestamp'], unit='ms', utc=True)
 
-        logging.info(f"Successfully fetched {len(df)} candles for {symbol} from {exchange.id}")
+        logger.info(f"Successfully fetched {len(df)} candles for {symbol} from {exchange.id}")
         return df
 
     except (ccxt.BaseError, RuntimeError) as e:
-        logging.error(f"Error fetching data: {e}")
+        logger.error(f"Error fetching data: {e}")
         raise

--- a/trading_bot/exchange.py
+++ b/trading_bot/exchange.py
@@ -5,6 +5,9 @@ from typing import Optional
 from trading_bot.utils.retry import RetryPolicy, default_retry
 
 
+logger = logging.getLogger(__name__)
+
+
 def create_exchange(api_key=None, api_secret=None, api_passphrase=None, exchange_name="binance"):
     """Create a CCXT exchange instance with optional credentials.
 
@@ -26,7 +29,7 @@ def create_exchange(api_key=None, api_secret=None, api_passphrase=None, exchange
         return exchange
 
     except (AttributeError, ccxt.BaseError) as e:
-        logging.error(f"Failed to initialize exchange '{exchange_name}': {e}")
+        logger.error(f"Failed to initialize exchange '{exchange_name}': {e}")
         raise
 
 def execute_trade(
@@ -41,10 +44,10 @@ def execute_trade(
     policy = retry_policy or default_retry()
     try:
         order = policy.call(exchange.create_market_order, symbol, side, amount)
-        logging.info(
+        logger.info(
             f"Executed {side} order for {amount} {symbol}: id={order.get('id')}")
         return order
     except ccxt.BaseError as e:
-        logging.error(f"Order execution failed: {e}")
+        logger.error(f"Order execution failed: {e}")
         return None
 

--- a/trading_bot/signal_logger.py
+++ b/trading_bot/signal_logger.py
@@ -6,6 +6,9 @@ from typing import Optional
 from trading_bot.utils.state import default_state_dir
 
 
+logger = logging.getLogger(__name__)
+
+
 def _default_db_path() -> str:
     return os.path.join(default_state_dir(), "signals.db")
 
@@ -72,10 +75,10 @@ def log_signals_to_db(signals, symbol, strategy_id='sma', db_path=None):
                 )
             
             conn.commit()
-            logging.info(f"Logged {len(signals)} signals to database {db_path}")
+            logger.info(f"Logged {len(signals)} signals to database {db_path}")
             
     except sqlite3.Error as e:
-        logging.error(f"Database error: {e}")
+        logger.error(f"Database error: {e}")
         raise
 
 
@@ -106,12 +109,12 @@ def log_trade_to_db(trade, db_path=None):
                 ),
             )
             conn.commit()
-            logging.info(f"Logged trade {trade['side']} {trade['symbol']} to database {db_path}")
+            logger.info(f"Logged trade {trade['side']} {trade['symbol']} to database {db_path}")
     except sqlite3.Error as e:
-        logging.error(f"Database error: {e}")
+        logger.error(f"Database error: {e}")
         raise
     except (KeyError, ValueError, TypeError) as e:
-        logging.error(f"Error logging trade to database: {e}")
+        logger.error(f"Error logging trade to database: {e}")
         raise
 
 
@@ -164,7 +167,7 @@ def get_trades_from_db(symbol=None, limit=None, db_path=None):
             return cursor.fetchall()
 
     except sqlite3.Error as e:
-        logging.error(f"Database error: {e}")
+        logger.error(f"Database error: {e}")
         return []
 
 def get_signals_from_db(symbol=None, strategy_id=None, limit=None, db_path=None):
@@ -215,7 +218,7 @@ def get_signals_from_db(symbol=None, strategy_id=None, limit=None, db_path=None)
             return cursor.fetchall()
             
     except sqlite3.Error as e:
-        logging.error(f"Database error: {e}")
+        logger.error(f"Database error: {e}")
         return []
 
 
@@ -271,5 +274,5 @@ def mark_signal_handled(
             except sqlite3.IntegrityError:
                 return True
     except sqlite3.Error as e:
-        logging.error(f"Database error: {e}")
+        logger.error(f"Database error: {e}")
         raise

--- a/trading_bot/strategies/bbands.py
+++ b/trading_bot/strategies/bbands.py
@@ -2,6 +2,9 @@ import pandas as pd
 import logging
 
 
+logger = logging.getLogger(__name__)
+
+
 def bbands_strategy(df, window=20, num_std=2):
     """Generate trading signals based on Bollinger Bands.
 
@@ -14,11 +17,11 @@ def bbands_strategy(df, window=20, num_std=2):
         list: List of signals with timestamp, action and price.
     """
     if df is None or df.empty:
-        logging.warning("Empty dataframe provided to Bollinger strategy")
+        logger.warning("Empty dataframe provided to Bollinger strategy")
         return []
 
     if len(df) < window:
-        logging.warning(f"Not enough data for {window}-period Bollinger Bands")
+        logger.warning(f"Not enough data for {window}-period Bollinger Bands")
         return []
 
     df = df.copy()
@@ -52,5 +55,5 @@ def bbands_strategy(df, window=20, num_std=2):
                 'price': curr_close
             })
 
-    logging.info(f"Generated {len(signals)} Bollinger band signals")
+    logger.info(f"Generated {len(signals)} Bollinger band signals")
     return signals

--- a/trading_bot/strategies/confluence.py
+++ b/trading_bot/strategies/confluence.py
@@ -4,6 +4,9 @@ from typing import DefaultDict, Dict, List, Optional, Any
 import pandas as pd
 
 
+logger = logging.getLogger(__name__)
+
+
 def confluence_strategy(df: pd.DataFrame, members: Optional[List[str]] = None, required: int = 2):
     """Generate signals only when multiple strategies agree.
 
@@ -22,7 +25,7 @@ def confluence_strategy(df: pd.DataFrame, members: Optional[List[str]] = None, r
     try:
         from trading_bot.strategies import STRATEGY_REGISTRY  # avoid circular import
     except ImportError as e:
-        logging.error(f"Failed to import STRATEGY_REGISTRY: {e}")
+        logger.error(f"Failed to import STRATEGY_REGISTRY: {e}")
         return []
 
     # Collect signals from member strategies
@@ -30,12 +33,12 @@ def confluence_strategy(df: pd.DataFrame, members: Optional[List[str]] = None, r
     for name in members:
         strategy_fn = STRATEGY_REGISTRY.get(name)
         if not callable(strategy_fn):
-            logging.warning(f"Unknown strategy in confluence: {name}")
+            logger.warning(f"Unknown strategy in confluence: {name}")
             continue
         try:
             signals = strategy_fn(df)
         except Exception as exc:
-            logging.exception(f"Error executing strategy '{name}': {exc}")
+            logger.exception(f"Error executing strategy '{name}': {exc}")
             continue
         for sig in signals:
             ts = sig["timestamp"]

--- a/trading_bot/strategies/macd.py
+++ b/trading_bot/strategies/macd.py
@@ -2,6 +2,9 @@ import pandas as pd
 import logging
 
 
+logger = logging.getLogger(__name__)
+
+
 def macd_strategy(df, fast_period=12, slow_period=26, signal_period=9):
     """Generate trading signals based on MACD crossovers.
 
@@ -15,14 +18,14 @@ def macd_strategy(df, fast_period=12, slow_period=26, signal_period=9):
         list: dictionaries with ``timestamp``, ``action`` and ``price``.
     """
     if df is None or df.empty:
-        logging.warning("Empty dataframe provided to MACD strategy")
+        logger.warning("Empty dataframe provided to MACD strategy")
         return []
 
     if 'close' not in df.columns:
         raise KeyError('close')
 
     if len(df) < slow_period:
-        logging.warning(
+        logger.warning(
             f"Not enough data for {slow_period}-period EMA calculation"
         )
         return []
@@ -55,5 +58,5 @@ def macd_strategy(df, fast_period=12, slow_period=26, signal_period=9):
                 'price': df.iloc[i]['close']
             })
 
-    logging.info(f"Generated {len(signals)} MACD crossover signals")
+    logger.info(f"Generated {len(signals)} MACD crossover signals")
     return signals

--- a/trading_bot/strategies/rsi_strategy.py
+++ b/trading_bot/strategies/rsi_strategy.py
@@ -3,6 +3,9 @@ import logging
 
 from trading_bot.utils.config import get_config
 
+
+logger = logging.getLogger(__name__)
+
 CONFIG = get_config()
 DEFAULT_RSI_PERIOD = CONFIG.get("rsi_period", 14)
 DEFAULT_RSI_LOWER = CONFIG.get("rsi_lower", 30)
@@ -27,11 +30,11 @@ def rsi_crossover_strategy(
         list: List of dictionaries with 'timestamp', 'action', 'price'.
     """
     if df is None or df.empty:
-        logging.warning("Empty dataframe provided to RSI strategy")
+        logger.warning("Empty dataframe provided to RSI strategy")
         return []
 
     if len(df) < period:
-        logging.warning(f"Not enough data for {period}-period RSI calculation")
+        logger.warning(f"Not enough data for {period}-period RSI calculation")
         return []
 
     df = df.copy()
@@ -66,7 +69,7 @@ def rsi_crossover_strategy(
                 'price': df.iloc[i]['close']
             })
 
-    logging.info(f"Generated {len(signals)} RSI crossover signals")
+    logger.info(f"Generated {len(signals)} RSI crossover signals")
     return signals
 
 # TODO(Devin): integrate RSI signals into Streamlit dashboard

--- a/trading_bot/strategies/sma_strategy.py
+++ b/trading_bot/strategies/sma_strategy.py
@@ -4,6 +4,9 @@ from datetime import datetime
 
 from trading_bot.utils.config import get_config
 
+
+logger = logging.getLogger(__name__)
+
 CONFIG = get_config()
 DEFAULT_SMA_SHORT = CONFIG.get("sma_short", 5)
 DEFAULT_SMA_LONG = CONFIG.get("sma_long", 20)
@@ -25,7 +28,7 @@ def sma_crossover_strategy(df, sma_short=DEFAULT_SMA_SHORT, sma_long=DEFAULT_SMA
         list: List of dictionaries with 'timestamp', 'action' ('buy'/'sell')
     """
     if len(df) < sma_long:
-        logging.warning(f"Not enough data for {sma_long}-period SMA calculation")
+        logger.warning(f"Not enough data for {sma_long}-period SMA calculation")
         return []
     
     df = df.copy()
@@ -56,5 +59,5 @@ def sma_crossover_strategy(df, sma_short=DEFAULT_SMA_SHORT, sma_long=DEFAULT_SMA
                 'price': df.iloc[i]['close']
             })
     
-    logging.info(f"Generated {len(signals)} trading signals")
+    logger.info(f"Generated {len(signals)} trading signals")
     return signals

--- a/trading_bot/tuner.py
+++ b/trading_bot/tuner.py
@@ -4,6 +4,9 @@ import itertools
 from trading_bot.backtester import run_backtest
 
 
+logger = logging.getLogger(__name__)
+
+
 DEFAULT_GRIDS = {
     "sma": {
         "sma_short": [5, 10, 15],
@@ -52,7 +55,7 @@ def tune(csv_path, strategy="sma", param_grid=None):
     results = []
     for combo in itertools.product(*values):
         params = dict(zip(keys, combo))
-        logging.info("Testing %s", params)
+        logger.info("Testing %s", params)
         stats = run_backtest(csv_path, strategy=strategy, **params)
         result = {"params": params}
         result.update(stats)

--- a/trading_bot/utils/config.py
+++ b/trading_bot/utils/config.py
@@ -5,6 +5,9 @@ from functools import lru_cache
 from typing import Dict, Tuple, Optional
 
 
+logger = logging.getLogger(__name__)
+
+
 def _deep_update(base: Dict, override: Dict) -> Dict:
     """Recursively merge ``override`` into ``base``."""
     for key, value in override.items():
@@ -36,7 +39,7 @@ def load_config(config_dir: Optional[str] = None) -> Dict:
         with open(config_path, "r") as f:
             config = json.load(f)
     except FileNotFoundError:
-        logging.warning("config.json not found, using default values")
+        logger.warning("config.json not found, using default values")
         config = {
             "symbol": "BTC/USDT",
             "timeframe": "1m",
@@ -56,7 +59,7 @@ def load_config(config_dir: Optional[str] = None) -> Dict:
                 local_cfg = json.load(f)
             config = _deep_update(config, local_cfg)
         except (OSError, json.JSONDecodeError) as e:  # noqa: BLE001
-            logging.warning(f"Failed loading config.local.json: {e}")
+            logger.warning(f"Failed loading config.local.json: {e}")
     # Override sensitive values with environment variables if available
     env_api_key = os.getenv("TRADING_BOT_API_KEY")
     if env_api_key:

--- a/trading_bot/utils/retry.py
+++ b/trading_bot/utils/retry.py
@@ -6,6 +6,9 @@ from typing import Callable, Optional, TypeVar
 
 from trading_bot.notify import send as notify_send
 
+
+logger = logging.getLogger(__name__)
+
 T = TypeVar("T")
 
 
@@ -43,7 +46,7 @@ class RetryPolicy:
         attempt = 0
         while True:
             if self._circuit_open():
-                logging.error(f"Circuit breaker open for {func.__name__}")
+                logger.error(f"Circuit breaker open for {func.__name__}")
                 notify_send(f"Circuit breaker open for {func.__name__}")
                 raise RuntimeError("circuit breaker open")
             try:
@@ -53,11 +56,11 @@ class RetryPolicy:
             except Exception as e:  # pragma: no cover - generic catch
                 attempt += 1
                 self._record_failure()
-                logging.warning(
+                logger.warning(
                     f"{func.__name__} failed on attempt {attempt}: {e}", exc_info=True
                 )
                 if attempt > self.retries:
-                    logging.error(
+                    logger.error(
                         f"{func.__name__} failed after {self.retries} retries: {e}",
                         exc_info=True,
                     )


### PR DESCRIPTION
## Summary
- use module-level loggers across project
- replace root logging calls with per-module loggers
- pin matplotlib to 3.8.4 to avoid yanked release
- remove duplicate logging imports after review

## Testing
- `pip install -r requirements.txt`
- `pytest -q`
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_6898c4fc477c832a8eaeb48c1087b1d1