### PR TITLE
[Core] Unify strategy function interface

### DIFF
--- a/trading_bot/strategies/bbands_strategy.py
+++ b/trading_bot/strategies/bbands_strategy.py
@@ -9,7 +9,12 @@ logger = logging.getLogger(__name__)
 
 
 @register_strategy("bbands")
-def bbands_strategy(df: pd.DataFrame, window: int = 20, num_std: float = 2) -> List[Dict[str, Any]]:
+def bbands_strategy(
+    df: pd.DataFrame,
+    window: int = 20,
+    num_std: float = 2,
+    **_kwargs,
+) -> List[Dict[str, Any]]:
     """Generate trading signals using Bollinger Bands crossovers.
 
     Args:

--- a/trading_bot/strategies/confluence_strategy.py
+++ b/trading_bot/strategies/confluence_strategy.py
@@ -21,6 +21,7 @@ def confluence_strategy(
     df: pd.DataFrame,
     members: Optional[List[str]] = None,
     required: int = METADATA["required_count"],
+    **_kwargs,
 ):
     """Generate signals only when multiple strategies agree.
 

--- a/trading_bot/strategies/macd_strategy.py
+++ b/trading_bot/strategies/macd_strategy.py
@@ -14,6 +14,7 @@ def macd_strategy(
     fast_period: int = 12,
     slow_period: int = 26,
     signal_period: int = 9,
+    **_kwargs,
 ) -> List[Dict[str, Any]]:
     """Generate trading signals based on MACD crossovers.
 

--- a/trading_bot/strategies/rsi_strategy.py
+++ b/trading_bot/strategies/rsi_strategy.py
@@ -21,6 +21,7 @@ def rsi_strategy(
     period: int = DEFAULT_RSI_PERIOD,
     lower_thresh: float = DEFAULT_RSI_LOWER,
     upper_thresh: float = DEFAULT_RSI_UPPER,
+    **_kwargs,
 ) -> List[Dict[str, Any]]:
     """Generate trading signals based on RSI threshold crossovers.
 

--- a/trading_bot/strategies/sma_strategy.py
+++ b/trading_bot/strategies/sma_strategy.py
@@ -18,6 +18,7 @@ def sma_strategy(
     df: pd.DataFrame,
     sma_short: int = DEFAULT_SMA_SHORT,
     sma_long: int = DEFAULT_SMA_LONG,
+    **_kwargs,
 ) -> List[Dict[str, Any]]:
     """
     SMA crossover strategy.


### PR DESCRIPTION
## Summary
- simplify signal generation API with keyword arguments
- allow strategies to accept **kwargs and ignore extras
- test that run_backtest forwards strategy parameters via kwargs

## Testing
- `pytest -q`
- `flake8` *(fails: numerous existing style errors in repository)*

------
https://chatgpt.com/codex/tasks/task_e_689e06f34950832a8784dbaa72dd3272