### PR TITLE
[Types] Mark package as typed and strengthen type checking

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,6 +11,10 @@ repos:
     rev: v0.5.7
     hooks:
       - id: ruff
+  - repo: https://github.com/pre-commit/mirrors-mypy
+    rev: v1.11.2
+    hooks:
+      - id: mypy
   - repo: https://github.com/Yelp/detect-secrets
     rev: v1.5.0
     hooks:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
 include = ["trading_bot"]
 
 [tool.setuptools.package-data]
-"trading_bot" = ["*.json"]
+"trading_bot" = ["*.json", "py.typed"]
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
## Summary
- mark package as typed via py.typed and packaging config
- add mypy to pre-commit hooks
- expand type hints in main module for safer analysis and live trading

## Testing
- `mypy trading_bot`
- `flake8` *(fails: E302 expected 2 blank lines, E501 line too long, etc.)*
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e3eacce30832aa4564d1afba01b20