### PR TITLE
Add dynamic stop-loss and take-profit to live trading

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ Default settings live in [`config.json`](config.json). Key options include:
 - Strategy parameters such as `sma_short`, `rsi_period`, `macd_fast`, or `bbands_window`.
 - API credentials and trade sizing under `api_key`, `api_secret`, and `trade_size`.
 - Risk controls and broker settings in the nested `risk` and `broker` sections.
+- Per-trade exits with `stop_loss_pct` and `take_profit_pct` to automatically
+  close positions when price moves beyond configured thresholds.
 
 Any value can be overridden from the command line by passing the corresponding flag, e.g.:
 

--- a/config.json
+++ b/config.json
@@ -16,6 +16,8 @@
     "api_secret": "",
     "api_passphrase": "",
     "trade_size": 1.0,
+    "stop_loss_pct": 0.02,
+    "take_profit_pct": 0.05,
     "min_balance_threshold": 0,
     "min_trade_interval_sec": 60,
     "max_position_pct": 1.0,

--- a/docs/live_trading.md
+++ b/docs/live_trading.md
@@ -62,6 +62,17 @@ trading-bot --live --max-trades-per-day 5 --max-position-pct 0.1 --trading-windo
 These safeguards complement stop-loss and take-profit rules by preventing
 over-trading in unfavourable conditions.
 
+To automatically attach protective exits to each trade, configure
+`stop_loss_pct` and `take_profit_pct` in `config.json`.
+For example:
+
+```json
+"stop_loss_pct": 0.02,
+"take_profit_pct": 0.05
+```
+
+This will sell a position if price falls 2% below entry or rises 5% above it.
+
 To automatically limit exposure in both backtests and live trading, set
 `max_position_pct` in your `config.json`. For example, adding
 

--- a/tests/test_live_dynamic_exits.py
+++ b/tests/test_live_dynamic_exits.py
@@ -1,0 +1,74 @@
+import importlib
+import logging
+from datetime import datetime, timezone
+
+import pytest
+
+from trading_bot.broker import PaperBroker
+
+
+@pytest.mark.parametrize(
+    "price_path,stop_pct,take_pct,log_msg",
+    [
+        ([100, 89], 0.1, 0.0, "Stop-loss triggered"),
+        ([100, 111], 0.0, 0.1, "Take-profit target hit"),
+    ],
+)
+def test_dynamic_exits(price_path, stop_pct, take_pct, log_msg, monkeypatch, tmp_path, caplog):
+    main = importlib.import_module("trading_bot.main")
+
+    prices = iter(price_path)
+
+    class DummyExchange:
+        def fetch_ticker(self, _):
+            return {"last": next(prices)}
+
+    exchange = DummyExchange()
+    broker = PaperBroker(starting_cash=1000, fees_bps=0, slippage_bps=0)
+
+    call = {"n": 0}
+
+    def fake_analysis(*args, **kwargs):
+        if call["n"] == 0:
+            call["n"] += 1
+            return [
+                {
+                    "action": "buy",
+                    "price": 100.0,
+                    "timestamp": datetime.now(timezone.utc),
+                }
+            ]
+        return []
+
+    monkeypatch.setattr(main, "run_single_analysis", fake_analysis)
+    monkeypatch.setattr(main, "mark_signal_handled", lambda *a, **k: False)
+
+    sleep_calls = {"n": 0}
+
+    def fake_sleep(_):
+        sleep_calls["n"] += 1
+        if sleep_calls["n"] >= 2:
+            raise KeyboardInterrupt()
+
+    monkeypatch.setattr(main.time, "sleep", fake_sleep)
+
+    with caplog.at_level(logging.INFO):
+        with pytest.raises(KeyboardInterrupt):
+            main.run_live_mode(
+                ["BTC/USDT"],
+                "1m",
+                2,
+                3,
+                exchange=exchange,
+                broker=broker,
+                live_trade=False,
+                trade_amount=1,
+                fee_bps=0,
+                stop_loss_pct=stop_pct,
+                take_profit_pct=take_pct,
+                interval_seconds=1,
+                state_dir=str(tmp_path),
+            )
+
+    assert broker.get_open_positions() == {}
+    assert log_msg in caplog.text


### PR DESCRIPTION
## Summary
- allow configuring stop_loss_pct and take_profit_pct in config and CLI
- integrate ExitManager into live trading loop to trigger protective exits
- document dynamic exit settings and add tests

## Testing
- `pytest -q`
- `flake8` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2030b2ed8832a93dda17f46345180